### PR TITLE
Fixed sponsor page style

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -304,7 +304,7 @@ const GlobalStyles = createGlobalStyle`
   }
 
   .page-sponsors .content {
-    padding: 1em;
+    padding: 0em;
   }
 
   .page-sponsors .footer {

--- a/src/pages/sponsors.js
+++ b/src/pages/sponsors.js
@@ -5,8 +5,8 @@ import Footer from "../components/footer";
 
 const Sponsors = () => (
   <Layout>
-    <main>
-    <Header />
+    <main className="page-sponsors">
+      <Header />
       <section className="content">
         <div className="grid">
           <div className="grid-full">
@@ -30,12 +30,14 @@ const Sponsors = () => (
                 you to attend in-person.
               </p>
 
-              <a
-                className="button-primary"
-                href="https://www.jsconfhi.com/JS-Conf-Hawaii-2020-Sponsorship-Info.pdf"
-              >
-                Download prospectus
-              </a>
+              <p>
+                <a
+                  className="button-primary"
+                  href="https://www.jsconfhi.com/JS-Conf-Hawaii-2020-Sponsorship-Info.pdf"
+                >
+                  Download Prospectus
+                </a>
+              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
- Added a <p> tag around the button, reflecting style on the rest of the site and remedying overlap of footer bar over prospectus button

- Added "page-sponsors" className to main section, reflecting style that got lost from site transfer

- Changed padding on ".page-sponsors .content" to 0em that was causing thick footer