### PR TITLE
Fixed visual bug for button in Windows

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -258,6 +258,7 @@ const GlobalStyles = createGlobalStyle`
     padding: 0;
     margin: 0;
     font-size: 24px;
+    background-color: transparent;
   }
 
   .newsletter .description button {


### PR DESCRIPTION
Switch from a tag to button caused visual bug in Windows where hamburger background was gray. Changed background-color in CSS to transparent and visual artifact went away.